### PR TITLE
fix: compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -47,9 +47,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arrayvec"
@@ -97,9 +97,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bumpalo"
@@ -127,9 +127,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "libc",
 ]
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
  "rand",
@@ -771,7 +771,7 @@ dependencies = [
 [[package]]
 name = "plonky2"
 version = "0.1.4"
-source = "git+https://github.com/mir-protocol/plonky2.git#bf1ed7839796a885012f8eeaf7a88191e4cc85f9"
+source = "git+https://github.com/mir-protocol/plonky2.git#eb7bb4610246adac7a11d5d547a90c5fbeaada5d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -996,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1028,11 +1028,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.6"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1068,29 +1068,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1177,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1196,22 +1196,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -1332,7 +1332,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1410,45 +1410,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
 
 [[package]]
 name = "zeroize"

--- a/curta/src/air/mod.rs
+++ b/curta/src/air/mod.rs
@@ -31,6 +31,10 @@ pub trait RAirData {
     /// The data needed for each round
     fn round_data(&self) -> Vec<RoundDatum>;
 
+    fn num_columns(&self) -> usize {
+        self.round_data().iter().map(|d| d.num_columns).sum()
+    }
+
     fn num_public_inputs(&self) -> usize;
 
     fn num_rounds(&self) -> usize {

--- a/curta/src/chip/bool.rs
+++ b/curta/src/chip/bool.rs
@@ -111,7 +111,7 @@ mod tests {
     #[derive(Debug, Clone, Copy)]
     pub struct SelectorTest;
 
-    impl const AirParameters for SelectorTest {
+    impl AirParameters for SelectorTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/bool.rs
+++ b/curta/src/chip/bool.rs
@@ -163,7 +163,7 @@ mod tests {
     //     for msg in rx.iter() {
     //         assert!(msg == 1);
     //     }
-    //     let stark = Starky::<_, { L::num_columns() }>::new(air);
+    //     let stark = Starky::new(air);
     //     let config = SC::standard_fast_config(L::num_rows());
 
     //     // Generate proof and verify as a stark

--- a/curta/src/chip/builder/mod.rs
+++ b/curta/src/chip/builder/mod.rs
@@ -371,7 +371,7 @@ pub(crate) mod tests {
             writer.write_instruction(&constr_1, i);
             writer.write_instruction(&constr_2, i);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark
@@ -431,7 +431,7 @@ pub(crate) mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/builder/mod.rs
+++ b/curta/src/chip/builder/mod.rs
@@ -278,7 +278,7 @@ pub(crate) mod tests {
     #[derive(Debug, Clone)]
     pub struct FibonacciParameters;
 
-    impl const AirParameters for FibonacciParameters {
+    impl AirParameters for FibonacciParameters {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
         type Instruction = EmptyInstruction<GoldilocksField>;
@@ -384,7 +384,7 @@ pub(crate) mod tests {
     #[derive(Debug, Clone)]
     pub struct SimpleTestParameters;
 
-    impl const AirParameters for SimpleTestParameters {
+    impl AirParameters for SimpleTestParameters {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
         type Instruction = EmptyInstruction<GoldilocksField>;

--- a/curta/src/chip/ec/edwards/add.rs
+++ b/curta/src/chip/ec/edwards/add.rs
@@ -169,7 +169,7 @@ mod tests {
             writer.write_row_instructions(&generator.air_data, i);
         });
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/ec/edwards/add.rs
+++ b/curta/src/chip/ec/edwards/add.rs
@@ -126,7 +126,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     pub struct Ed25519AddTest;
 
-    impl const AirParameters for Ed25519AddTest {
+    impl AirParameters for Ed25519AddTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/ec/edwards/scalar_mul/air.rs
+++ b/curta/src/chip/ec/edwards/scalar_mul/air.rs
@@ -29,7 +29,7 @@ pub struct ScalarMulEd25519<F: PrimeField64, E: CubicParameters<F>>(
     core::marker::PhantomData<(F, E)>,
 );
 
-impl<F: PrimeField64, E: CubicParameters<F>> const AirParameters for ScalarMulEd25519<F, E> {
+impl<F: PrimeField64, E: CubicParameters<F>> AirParameters for ScalarMulEd25519<F, E> {
     type Field = F;
     type CubicParams = E;
 

--- a/curta/src/chip/ec/edwards/scalar_mul/gadget.rs
+++ b/curta/src/chip/ec/edwards/scalar_mul/gadget.rs
@@ -203,7 +203,7 @@ mod tests {
                 }
             });
         });
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/ec/edwards/scalar_mul/gadget.rs
+++ b/curta/src/chip/ec/edwards/scalar_mul/gadget.rs
@@ -147,7 +147,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     pub struct Ed25519ScalarMulTest;
 
-    impl const AirParameters for Ed25519ScalarMulTest {
+    impl AirParameters for Ed25519ScalarMulTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/ec/edwards/scalar_mul/generator.rs
+++ b/curta/src/chip/ec/edwards/scalar_mul/generator.rs
@@ -12,7 +12,7 @@ use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
-use super::air::{ScalarMulEd25519, ED_NUM_COLUMNS};
+use super::air::ScalarMulEd25519;
 use super::gadget::EdScalarMulGadget;
 use crate::chip::ec::edwards::ed25519::{Ed25519, Ed25519BaseField};
 use crate::chip::ec::edwards::EdwardsParameters;
@@ -33,7 +33,7 @@ use crate::plonky2::stark::gadget::StarkGadget;
 use crate::plonky2::stark::generator::simple::SimpleStarkWitnessGenerator;
 use crate::plonky2::stark::Starky;
 
-pub type EdDSAStark<F, E> = Starky<Chip<ScalarMulEd25519<F, E>>, ED_NUM_COLUMNS>;
+pub type EdDSAStark<F, E> = Starky<Chip<ScalarMulEd25519<F, E>>>;
 
 const AFFINE_POINT_TARGET_NUM_LIMBS: usize = 16;
 
@@ -140,7 +140,7 @@ impl<F: RichField + Extendable<D>, const D: usize> ScalarMulEd25519Gadget<F, D>
             .map(|x| x.unwrap())
             .collect::<Vec<_>>();
 
-        let stark = Starky::<_, ED_NUM_COLUMNS>::new(air);
+        let stark = Starky::new(air);
         let config =
             StarkyConfig::<F, C, D>::standard_fast_config(ScalarMulEd25519::<F, E>::num_rows());
         let virtual_proof = self.add_virtual_stark_proof(&stark, &config);

--- a/curta/src/chip/field/add.rs
+++ b/curta/src/chip/field/add.rs
@@ -252,7 +252,7 @@ mod tests {
                 writer.write_row_instructions(&generator.air_data, i);
             });
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/field/add.rs
+++ b/curta/src/chip/field/add.rs
@@ -194,7 +194,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     struct FpAddTest;
 
-    impl const AirParameters for FpAddTest {
+    impl AirParameters for FpAddTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/field/den.rs
+++ b/curta/src/chip/field/den.rs
@@ -185,7 +185,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     struct DenTest;
 
-    impl const AirParameters for DenTest {
+    impl AirParameters for DenTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/field/den.rs
+++ b/curta/src/chip/field/den.rs
@@ -242,7 +242,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/field/inner_product.rs
+++ b/curta/src/chip/field/inner_product.rs
@@ -257,7 +257,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/field/inner_product.rs
+++ b/curta/src/chip/field/inner_product.rs
@@ -189,7 +189,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     struct FpInnerProductTest;
 
-    impl const AirParameters for FpInnerProductTest {
+    impl AirParameters for FpInnerProductTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/field/mul.rs
+++ b/curta/src/chip/field/mul.rs
@@ -223,7 +223,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/field/mul.rs
+++ b/curta/src/chip/field/mul.rs
@@ -166,7 +166,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     struct FpMulTest;
 
-    impl const AirParameters for FpMulTest {
+    impl AirParameters for FpMulTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/field/mul_const.rs
+++ b/curta/src/chip/field/mul_const.rs
@@ -171,7 +171,7 @@ mod tests {
     #[derive(Clone, Debug, Copy)]
     struct FpMulConstTest;
 
-    impl const AirParameters for FpMulConstTest {
+    impl AirParameters for FpMulConstTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/field/mul_const.rs
+++ b/curta/src/chip/field/mul_const.rs
@@ -229,7 +229,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/hash/sha/sha256/builder_gadget.rs
+++ b/curta/src/chip/hash/sha/sha256/builder_gadget.rs
@@ -6,7 +6,7 @@ use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
-use super::generator::{SHA256AirParameters, SHA256Generator, SHA256_COLUMNS};
+use super::generator::{SHA256AirParameters, SHA256Generator};
 use super::SHA256PublicData;
 use crate::chip::builder::AirBuilder;
 use crate::chip::trace::generator::ArithmeticGenerator;
@@ -114,7 +114,7 @@ impl<F: RichField + Extendable<D>, E: CubicParameters<F>, const D: usize> SHA256
 
         self.add_simple_generator(sha_generator);
 
-        let stark = Starky::<_, SHA256_COLUMNS>::new(air);
+        let stark = Starky::new(air);
         let config =
             StarkyConfig::<F, C, D>::standard_fast_config(SHA256AirParameters::<F, E>::num_rows());
         let virtual_proof = self.add_virtual_stark_proof(&stark, &config);

--- a/curta/src/chip/hash/sha/sha256/generator.rs
+++ b/curta/src/chip/hash/sha/sha256/generator.rs
@@ -36,7 +36,7 @@ pub struct MessageChunks {
 #[derive(Debug, Clone)]
 pub struct SHA256Generator<F: PrimeField64, E: CubicParameters<F>> {
     pub gadget: SHA256Gadget,
-    pub table: ByteLookupTable<F>,
+    pub table: ByteLookupTable,
     pub padded_messages: Vec<Target>,
     pub chunk_sizes: Vec<usize>,
     pub trace_generator: ArithmeticGenerator<SHA256AirParameters<F, E>>,

--- a/curta/src/chip/hash/sha/sha256/generator.rs
+++ b/curta/src/chip/hash/sha/sha256/generator.rs
@@ -11,7 +11,7 @@ use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::util::serialization::Buffer;
 
 use super::{SHA256Gadget, SHA256PublicData, INITIAL_HASH, ROUND_CONSTANTS};
-use crate::chip::register::{Register, RegisterSized};
+use crate::chip::register::Register;
 use crate::chip::trace::generator::ArithmeticGenerator;
 use crate::chip::uint::bytes::lookup_table::table::ByteLookupTable;
 use crate::chip::uint::operations::instruction::U32Instruction;
@@ -43,7 +43,7 @@ pub struct SHA256Generator<F: PrimeField64, E: CubicParameters<F>> {
     pub pub_values_target: SHA256PublicData<Target>,
 }
 
-impl<F: PrimeField64, E: CubicParameters<F>> const AirParameters for SHA256AirParameters<F, E> {
+impl<F: PrimeField64, E: CubicParameters<F>> AirParameters for SHA256AirParameters<F, E> {
     type Field = F;
     type CubicParams = E;
 
@@ -123,7 +123,7 @@ impl SHA256PublicData<Target> {
         chunk_sizes: &[usize],
     ) -> Self {
         let public_w_targets = (0..16 * 1024)
-            .map(|_| builder.add_virtual_target_arr::<{ U32Register::size_of() }>())
+            .map(|_| builder.add_virtual_target_arr::<4>())
             .collect::<Vec<_>>();
 
         // let end_bits_targets = builder.add_virtual_targets(1024);
@@ -134,10 +134,8 @@ impl SHA256PublicData<Target> {
             end_bits_targets.extend((0..(chunk_size - 1)).map(|_| builder.zero()));
             end_bits_targets.push(builder.one());
 
-            hash_state_targets.extend(
-                (0..8 * (chunk_size - 1))
-                    .map(|_| builder.add_virtual_target_arr::<{ U32Register::size_of() }>()),
-            );
+            hash_state_targets
+                .extend((0..8 * (chunk_size - 1)).map(|_| builder.add_virtual_target_arr::<4>()));
 
             // Convert digest to little endian u32 chunks
             let u32_digest = digest.chunks_exact(4).map(|arr| {

--- a/curta/src/chip/hash/sha/sha256/mod.rs
+++ b/curta/src/chip/hash/sha/sha256/mod.rs
@@ -663,13 +663,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let expected_digests: Vec<[u32; 8]> = (0..256)
-            .flat_map(|_| {
-                [
-                    expected_digest_1.clone(),
-                    expected_digest_long.clone(),
-                    expected_digest_2.clone(),
-                ]
-            })
+            .flat_map(|_| [expected_digest_1, expected_digest_long, expected_digest_2])
             .map(|digest| {
                 hex::decode(digest)
                     .unwrap()

--- a/curta/src/chip/hash/sha/sha256/mod.rs
+++ b/curta/src/chip/hash/sha/sha256/mod.rs
@@ -597,7 +597,7 @@ mod tests {
     #[derive(Debug, Clone, Copy)]
     pub struct SHA256Test;
 
-    impl const AirParameters for SHA256Test {
+    impl AirParameters for SHA256Test {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/hash/sha/sha256/mod.rs
+++ b/curta/src/chip/hash/sha/sha256/mod.rs
@@ -701,7 +701,7 @@ mod tests {
         });
 
         let public_inputs = writer.0.public.read().unwrap().clone();
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/instruction/cycle.rs
+++ b/curta/src/chip/instruction/cycle.rs
@@ -164,7 +164,7 @@ mod tests {
     #[derive(Clone, Debug)]
     pub struct CycleTest;
 
-    impl const AirParameters for CycleTest {
+    impl AirParameters for CycleTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/instruction/cycle.rs
+++ b/curta/src/chip/instruction/cycle.rs
@@ -212,7 +212,7 @@ mod tests {
             air.eval(&mut window_parser);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/mod.rs
+++ b/curta/src/chip/mod.rs
@@ -19,7 +19,6 @@ pub mod trace;
 pub mod uint;
 pub mod utils;
 
-#[const_trait]
 pub trait AirParameters {
     type Field: PrimeField64;
 
@@ -60,7 +59,7 @@ pub struct Chip<L: AirParameters> {
     num_global_values: usize,
 }
 
-impl<L: ~const AirParameters> Starky<Chip<L>> {
+impl<L: AirParameters> Starky<Chip<L>> {
     pub fn from_chip(chip: Chip<L>) -> Self {
         Self::new(chip)
     }

--- a/curta/src/chip/mod.rs
+++ b/curta/src/chip/mod.rs
@@ -60,7 +60,7 @@ pub struct Chip<L: AirParameters> {
     num_global_values: usize,
 }
 
-impl<L: ~const AirParameters> Starky<Chip<L>, { L::num_columns() }> {
+impl<L: ~const AirParameters> Starky<Chip<L>> {
     pub fn from_chip(chip: Chip<L>) -> Self {
         Self::new(chip)
     }

--- a/curta/src/chip/register/bit.rs
+++ b/curta/src/chip/register/bit.rs
@@ -27,7 +27,7 @@ impl RegisterSerializable for BitRegister {
     }
 }
 
-impl const RegisterSized for BitRegister {
+impl RegisterSized for BitRegister {
     fn size_of() -> usize {
         1
     }

--- a/curta/src/chip/register/cubic.rs
+++ b/curta/src/chip/register/cubic.rs
@@ -39,7 +39,7 @@ impl RegisterSerializable for CubicRegister {
     }
 }
 
-impl const RegisterSized for CubicRegister {
+impl RegisterSized for CubicRegister {
     fn size_of() -> usize {
         3
     }

--- a/curta/src/chip/register/element.rs
+++ b/curta/src/chip/register/element.rs
@@ -18,7 +18,7 @@ impl RegisterSerializable for ElementRegister {
     }
 }
 
-impl const RegisterSized for ElementRegister {
+impl RegisterSized for ElementRegister {
     fn size_of() -> usize {
         1
     }

--- a/curta/src/chip/register/mod.rs
+++ b/curta/src/chip/register/mod.rs
@@ -34,7 +34,6 @@ where
 }
 
 /// Ensures that the register has a fixed size.
-#[const_trait]
 pub trait RegisterSized {
     /// Returns the expected size of the register in cells.
     fn size_of() -> usize;

--- a/curta/src/chip/register/u16.rs
+++ b/curta/src/chip/register/u16.rs
@@ -20,7 +20,7 @@ impl RegisterSerializable for U16Register {
     }
 }
 
-impl const RegisterSized for U16Register {
+impl RegisterSized for U16Register {
     fn size_of() -> usize {
         1
     }

--- a/curta/src/chip/table/evaluation/mod.rs
+++ b/curta/src/chip/table/evaluation/mod.rs
@@ -170,7 +170,7 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct EvalTest;
 
-    impl const AirParameters for EvalTest {
+    impl AirParameters for EvalTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
         type Instruction = EmptyInstruction<GoldilocksField>;

--- a/curta/src/chip/table/evaluation/mod.rs
+++ b/curta/src/chip/table/evaluation/mod.rs
@@ -225,7 +225,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark
@@ -277,7 +277,7 @@ mod tests {
         for msg in rx.iter() {
             assert!(msg == 1);
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/trace/generator.rs
+++ b/curta/src/chip/trace/generator.rs
@@ -17,7 +17,7 @@ pub struct ArithmeticGenerator<L: AirParameters> {
     pub air_data: AirTraceData<L>,
 }
 
-impl<L: ~const AirParameters> ArithmeticGenerator<L> {
+impl<L: AirParameters> ArithmeticGenerator<L> {
     pub fn new(air_data: AirTraceData<L>) -> Self {
         let num_public_inputs = air_data.num_public_inputs;
         let num_global_values = air_data.num_global_values;

--- a/curta/src/chip/uint/bytes/bit_operations/and.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/and.rs
@@ -119,7 +119,7 @@ pub mod tests {
             writer.write_row_instructions(&generator.air_data, i);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark
@@ -171,7 +171,7 @@ pub mod tests {
             writer.write_row_instructions(&generator.air_data, i);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/bit_operations/and.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/and.rs
@@ -67,7 +67,7 @@ pub mod tests {
     #[derive(Debug, Clone)]
     pub struct AndTest<const N: usize>;
 
-    impl<const N: usize> const AirParameters for AndTest<N> {
+    impl<const N: usize> AirParameters for AndTest<N> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/bit_operations/not.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/not.rs
@@ -111,7 +111,7 @@ pub mod tests {
             writer.write_instruction(&not, i);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/bit_operations/not.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/not.rs
@@ -63,7 +63,7 @@ pub mod tests {
     #[derive(Debug, Clone)]
     pub struct NotTest<const N: usize>;
 
-    impl<const N: usize> const AirParameters for NotTest<N> {
+    impl<const N: usize> AirParameters for NotTest<N> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/bit_operations/rotate.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/rotate.rs
@@ -193,7 +193,7 @@ pub mod tests {
             air.eval(&mut window_parser);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark
@@ -258,7 +258,7 @@ pub mod tests {
             air.eval(&mut window_parser);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/bit_operations/rotate.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/rotate.rs
@@ -125,7 +125,7 @@ pub mod tests {
     #[derive(Debug, Clone)]
     pub struct RotateTest<const N: usize, const M: usize>;
 
-    impl<const N: usize, const M: usize> const AirParameters for RotateTest<N, M> {
+    impl<const N: usize, const M: usize> AirParameters for RotateTest<N, M> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/bit_operations/shift.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/shift.rs
@@ -142,7 +142,7 @@ pub mod tests {
     #[derive(Debug, Clone)]
     pub struct ShfitTest<const N: usize, const M: usize>;
 
-    impl<const N: usize, const M: usize> const AirParameters for ShfitTest<N, M> {
+    impl<const N: usize, const M: usize> AirParameters for ShfitTest<N, M> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/bit_operations/shift.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/shift.rs
@@ -209,7 +209,7 @@ pub mod tests {
             air.eval(&mut window_parser);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark
@@ -264,7 +264,7 @@ pub mod tests {
             air.eval(&mut window_parser);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/bit_operations/xor.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/xor.rs
@@ -71,7 +71,7 @@ pub mod tests {
     #[derive(Debug, Clone)]
     pub struct XorTest<const N: usize>;
 
-    impl<const N: usize> const AirParameters for XorTest<N> {
+    impl<const N: usize> AirParameters for XorTest<N> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/bit_operations/xor.rs
+++ b/curta/src/chip/uint/bytes/bit_operations/xor.rs
@@ -123,7 +123,7 @@ pub mod tests {
             writer.write_instruction(&xor, i);
         }
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/decode.rs
+++ b/curta/src/chip/uint/bytes/decode.rs
@@ -60,7 +60,7 @@ mod tests {
     #[derive(Debug, Clone, Copy)]
     struct DecodeTest;
 
-    impl const AirParameters for DecodeTest {
+    impl AirParameters for DecodeTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/decode.rs
+++ b/curta/src/chip/uint/bytes/decode.rs
@@ -100,7 +100,7 @@ mod tests {
                 writer.write(&bit, &F::from_canonical_u8(bit_val), i);
             }
         }
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/gadget/air.rs
+++ b/curta/src/chip/uint/bytes/gadget/air.rs
@@ -7,8 +7,6 @@ use crate::chip::uint::bytes::lookup_table::ByteInstructionSet;
 use crate::chip::AirParameters;
 use crate::math::prelude::*;
 
-pub(crate) const NUM_BYTE_GADGET_COLUMNS: usize = 103 + 51;
-
 #[derive(Debug, Clone, Copy)]
 pub struct ByteGadgetParameters<F, E, const D: usize>(PhantomData<(F, E)>);
 

--- a/curta/src/chip/uint/bytes/gadget/air.rs
+++ b/curta/src/chip/uint/bytes/gadget/air.rs
@@ -10,7 +10,7 @@ use crate::math::prelude::*;
 #[derive(Debug, Clone, Copy)]
 pub struct ByteGadgetParameters<F, E, const D: usize>(PhantomData<(F, E)>);
 
-impl<F: RichField + Extendable<D>, E: CubicParameters<F>, const D: usize> const AirParameters
+impl<F: RichField + Extendable<D>, E: CubicParameters<F>, const D: usize> AirParameters
     for ByteGadgetParameters<F, E, D>
 {
     type Field = F;

--- a/curta/src/chip/uint/bytes/gadget/generator.rs
+++ b/curta/src/chip/uint/bytes/gadget/generator.rs
@@ -21,7 +21,7 @@ pub struct BytesLookupGenerator<F: RichField + Extendable<D>, E: CubicParameters
     operations: Vec<ByteOperation<Target>>,
     air_operations: Vec<ByteOperation<ByteRegister>>,
     trace_generator: ArithmeticGenerator<ByteGadgetParameters<F, E, D>>,
-    table: ByteLookupTable<F>,
+    table: ByteLookupTable,
 }
 
 pub struct ByteOperationGenerator {}
@@ -34,7 +34,7 @@ impl<F: RichField + Extendable<D>, E: CubicParameters<F>, const D: usize>
         operations: Vec<ByteOperation<Target>>,
         air_operations: Vec<ByteOperation<ByteRegister>>,
         trace_generator: ArithmeticGenerator<ByteGadgetParameters<F, E, D>>,
-        table: ByteLookupTable<F>,
+        table: ByteLookupTable,
     ) -> Self {
         Self {
             operations,

--- a/curta/src/chip/uint/bytes/gadget/mod.rs
+++ b/curta/src/chip/uint/bytes/gadget/mod.rs
@@ -8,7 +8,7 @@ use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
-use self::air::{ByteGadgetParameters, NUM_BYTE_GADGET_COLUMNS};
+use self::air::ByteGadgetParameters;
 use self::generator::BytesLookupGenerator;
 use crate::chip::builder::AirBuilder;
 use crate::chip::trace::generator::ArithmeticGenerator;
@@ -69,7 +69,7 @@ pub struct BytesGadget<F: RichField + Extendable<D>, E: CubicParameters<F>, cons
     operations: Vec<ByteOperation<Target>>,
     air_operations: Vec<ByteOperation<ByteRegister>>,
     lookup_operations: ByteLookupOperations,
-    table: ByteLookupTable<F>,
+    table: ByteLookupTable,
     air_builder: AirBuilder<ByteGadgetParameters<F, E, D>>,
 }
 
@@ -198,7 +198,7 @@ impl<F: RichField + Extendable<D>, E: CubicParameters<F>, const D: usize>
             BytesLookupGenerator::new(operations, air_operations, trace_generator.clone(), table);
         self.add_simple_generator(byte_generator);
 
-        let stark = Starky::<_, NUM_BYTE_GADGET_COLUMNS>::new(air);
+        let stark = Starky::new(air);
         let config = StarkyConfig::<F, C, D>::standard_fast_config(
             ByteGadgetParameters::<F, E, D>::num_rows(),
         );

--- a/curta/src/chip/uint/bytes/lookup_table/mod.rs
+++ b/curta/src/chip/uint/bytes/lookup_table/mod.rs
@@ -44,7 +44,7 @@ pub trait ByteInstructions:
 impl ByteInstructions for ByteInstructionSet {}
 
 impl<L: AirParameters> AirBuilder<L> {
-    pub fn byte_operations(&mut self) -> (ByteLookupOperations, ByteLookupTable<L::Field>)
+    pub fn byte_operations(&mut self) -> (ByteLookupOperations, ByteLookupTable)
     where
         L::Instruction: From<ByteInstructionSet>
             + From<SelectInstruction<BitRegister>>
@@ -62,7 +62,7 @@ impl<L: AirParameters> AirBuilder<L> {
     pub fn register_byte_lookup(
         &mut self,
         operation_values: ByteLookupOperations,
-        table: &ByteLookupTable<L::Field>,
+        table: &ByteLookupTable,
     ) {
         let multiplicities = table.multiplicity_data.multiplicities();
         let lookup_challenge = self.alloc_challenge::<CubicRegister>();
@@ -367,7 +367,7 @@ mod tests {
         writer.write_global_instructions(&generator.air_data);
         table.write_multiplicities(&writer);
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/bytes/lookup_table/mod.rs
+++ b/curta/src/chip/uint/bytes/lookup_table/mod.rs
@@ -178,7 +178,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct ByteOpTest<const N: usize>;
 
-    impl<const N: usize> const AirParameters for ByteOpTest<N> {
+    impl<const N: usize> AirParameters for ByteOpTest<N> {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/bytes/lookup_table/table.rs
+++ b/curta/src/chip/uint/bytes/lookup_table/table.rs
@@ -29,7 +29,7 @@ use crate::math::prelude::*;
 use crate::maybe_rayon::*;
 
 #[derive(Debug, Clone)]
-pub struct ByteLookupTable<F> {
+pub struct ByteLookupTable {
     pub a: ByteRegister,
     pub b: ByteRegister,
     pub results: [ByteRegister; NUM_BIT_OPPS],
@@ -44,7 +44,7 @@ impl<L: AirParameters> AirBuilder<L> {
     pub fn new_byte_lookup_table(
         &mut self,
         row_acc_challenges: ArrayRegister<CubicRegister>,
-    ) -> ByteLookupTable<L::Field>
+    ) -> ByteLookupTable
     where
         L::Instruction: From<ByteInstructionSet>
             + From<SelectInstruction<BitRegister>>
@@ -129,8 +129,8 @@ impl<L: AirParameters> AirBuilder<L> {
     }
 }
 
-impl<F: PrimeField64> ByteLookupTable<F> {
-    pub fn write_table_entries(&self, writer: &TraceWriter<F>) {
+impl ByteLookupTable {
+    pub fn write_table_entries<F: Field>(&self, writer: &TraceWriter<F>) {
         let operations_dict = self.multiplicity_data.operations_dict.clone();
         // Write the lookup table entries
         writer
@@ -181,7 +181,7 @@ impl<F: PrimeField64> ByteLookupTable<F> {
             });
     }
 
-    pub fn write_multiplicities(&self, writer: &TraceWriter<F>) {
+    pub fn write_multiplicities<F: Field>(&self, writer: &TraceWriter<F>) {
         // Assign multiplicities to the trace
         self.multiplicity_data.write_multiplicities(writer);
     }

--- a/curta/src/chip/uint/bytes/register.rs
+++ b/curta/src/chip/uint/bytes/register.rs
@@ -24,7 +24,7 @@ impl RegisterSerializable for ByteRegister {
     }
 }
 
-impl const RegisterSized for ByteRegister {
+impl RegisterSized for ByteRegister {
     fn size_of() -> usize {
         1
     }

--- a/curta/src/chip/uint/operations/instruction.rs
+++ b/curta/src/chip/uint/operations/instruction.rs
@@ -99,7 +99,7 @@ mod tests {
     #[derive(Debug, Clone)]
     struct U32OpTest;
 
-    impl const AirParameters for U32OpTest {
+    impl AirParameters for U32OpTest {
         type Field = GoldilocksField;
         type CubicParams = GoldilocksCubicParameters;
 

--- a/curta/src/chip/uint/operations/instruction.rs
+++ b/curta/src/chip/uint/operations/instruction.rs
@@ -221,7 +221,7 @@ mod tests {
         }
         table.write_multiplicities(&writer);
 
-        let stark = Starky::<_, { L::num_columns() }>::new(air);
+        let stark = Starky::new(air);
         let config = SC::standard_fast_config(L::num_rows());
 
         // Generate proof and verify as a stark

--- a/curta/src/chip/uint/register.rs
+++ b/curta/src/chip/uint/register.rs
@@ -29,7 +29,7 @@ impl<const N: usize> RegisterSerializable for ByteArrayRegister<N> {
     }
 }
 
-impl<const N: usize> const RegisterSized for ByteArrayRegister<N> {
+impl<const N: usize> RegisterSized for ByteArrayRegister<N> {
     fn size_of() -> usize {
         N
     }

--- a/curta/src/lib.rs
+++ b/curta/src/lib.rs
@@ -1,9 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(incomplete_features)]
-#![feature(adt_const_params)]
-#![feature(test)]
-#![feature(const_trait_impl)]
-#![feature(specialization)]
 #![allow(clippy::new_without_default)]
 #![feature(bigint_helper_methods)]
 

--- a/curta/src/lib.rs
+++ b/curta/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 #![feature(adt_const_params)]
 #![feature(test)]
 #![feature(const_trait_impl)]

--- a/curta/src/plonky2/stark/gadget.rs
+++ b/curta/src/plonky2/stark/gadget.rs
@@ -18,19 +18,19 @@ pub trait StarkGadget<
     const D: usize,
 >
 {
-    fn add_virtual_stark_proof<A, const COLUMNS: usize>(
+    fn add_virtual_stark_proof<A>(
         &mut self,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         config: &StarkyConfig<F, C, D>,
     ) -> StarkProofTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
         A: for<'a> RAir<RecursiveStarkParser<'a, F, D>>;
 
-    fn verify_stark_proof<A, const COLUMNS: usize>(
+    fn verify_stark_proof<A>(
         &mut self,
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         proof: StarkProofTarget<D>,
         public_inputs: &[Target],
     ) where
@@ -45,9 +45,9 @@ impl<
         const D: usize,
     > StarkGadget<F, C, D> for CircuitBuilder<F, D>
 {
-    fn add_virtual_stark_proof<A, const COLUMNS: usize>(
+    fn add_virtual_stark_proof<A>(
         &mut self,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         config: &StarkyConfig<F, C, D>,
     ) -> StarkProofTarget<D>
     where
@@ -57,10 +57,10 @@ impl<
         add_virtual_stark_proof(self, stark, config)
     }
 
-    fn verify_stark_proof<A, const COLUMNS: usize>(
+    fn verify_stark_proof<A>(
         &mut self,
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         proof: StarkProofTarget<D>,
         public_inputs: &[Target],
     ) where

--- a/curta/src/plonky2/stark/generator/simple.rs
+++ b/curta/src/plonky2/stark/generator/simple.rs
@@ -21,21 +21,21 @@ use crate::plonky2::stark::Starky;
 use crate::trace::generator::TraceGenerator;
 
 #[derive(Debug, Clone)]
-pub struct SimpleStarkWitnessGenerator<A, T: Clone, F, C, P, const D: usize, const COLUMNS: usize> {
+pub struct SimpleStarkWitnessGenerator<A, T: Clone, F, C, P, const D: usize> {
     config: StarkyConfig<F, C, D>,
-    pub stark: Starky<A, COLUMNS>,
+    pub stark: Starky<A>,
     pub proof_target: StarkProofTarget<D>,
     pub public_input_targets: Vec<Target>,
     pub trace_generator: T,
     _marker: core::marker::PhantomData<P>,
 }
 
-impl<A, T: Clone, F: RichField, C, const D: usize, const COLUMNS: usize>
-    SimpleStarkWitnessGenerator<A, T, F, C, <F as Packable>::Packing, D, COLUMNS>
+impl<A, T: Clone, F: RichField, C, const D: usize>
+    SimpleStarkWitnessGenerator<A, T, F, C, <F as Packable>::Packing, D>
 {
     pub fn new(
         config: StarkyConfig<F, C, D>,
-        stark: Starky<A, COLUMNS>,
+        stark: Starky<A>,
         proof_target: StarkProofTarget<D>,
         public_input_targets: Vec<Target>,
         trace_generator: T,
@@ -51,8 +51,8 @@ impl<A, T: Clone, F: RichField, C, const D: usize, const COLUMNS: usize>
     }
 }
 
-impl<A: 'static + Debug + Send + Sync, T: Clone, F, C, P, const D: usize, const COLUMNS: usize>
-    SimpleGenerator<F, D> for SimpleStarkWitnessGenerator<A, T, F, C, P, D, COLUMNS>
+impl<A: 'static + Debug + Send + Sync, T: Clone, F, C, P, const D: usize> SimpleGenerator<F, D>
+    for SimpleStarkWitnessGenerator<A, T, F, C, P, D>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F> + 'static,

--- a/curta/src/plonky2/stark/mod.rs
+++ b/curta/src/plonky2/stark/mod.rs
@@ -26,17 +26,17 @@ pub mod prover;
 pub mod verifier;
 
 #[derive(Debug, Clone)]
-pub struct Starky<A, const COLUMNS: usize> {
+pub struct Starky<A> {
     pub air: A,
 }
 
-impl<A, const COLUMNS: usize> Starky<A, COLUMNS> {
+impl<A> Starky<A> {
     pub fn new(air: A) -> Self {
         Self { air }
     }
 }
 
-impl<A, const COLUMNS: usize> Starky<A, COLUMNS> {
+impl<A> Starky<A> {
     fn air(&self) -> &A {
         &self.air
     }
@@ -149,17 +149,8 @@ impl<A, const COLUMNS: usize> Starky<A, COLUMNS> {
     }
 }
 
-impl<
-        'a,
-        A,
-        F,
-        C: GenericConfig<D, F = F>,
-        FE,
-        P,
-        const D: usize,
-        const D2: usize,
-        const COLUMNS: usize,
-    > Stark<StarkParser<'a, F, FE, P, D, D2>, StarkyConfig<F, C, D>> for Starky<A, COLUMNS>
+impl<'a, A, F, C: GenericConfig<D, F = F>, FE, P, const D: usize, const D2: usize>
+    Stark<StarkParser<'a, F, FE, P, D, D2>, StarkyConfig<F, C, D>> for Starky<A>
 where
     F: RichField + Extendable<D>,
     FE: FieldExtension<D2, BaseField = F>,
@@ -173,8 +164,8 @@ where
     }
 }
 
-impl<'a, A, F, C: GenericConfig<D, F = F>, const D: usize, const COLUMNS: usize>
-    Stark<RecursiveStarkParser<'a, F, D>, StarkyConfig<F, C, D>> for Starky<A, COLUMNS>
+impl<'a, A, F, C: GenericConfig<D, F = F>, const D: usize>
+    Stark<RecursiveStarkParser<'a, F, D>, StarkyConfig<F, C, D>> for Starky<A>
 where
     F: RichField + Extendable<D>,
     A: RAir<RecursiveStarkParser<'a, F, D>>,
@@ -215,9 +206,8 @@ pub(crate) mod tests {
         F: RichField + Extendable<D>,
         C: GenericConfig<D, F = F, FE = F::Extension>,
         const D: usize,
-        const COLUMNS: usize,
     >(
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         config: &StarkyConfig<F, C, D>,
         trace_generator: &T,
         public_inputs: &[F],
@@ -247,9 +237,8 @@ pub(crate) mod tests {
         F: RichField + Extendable<D>,
         C: GenericConfig<D, F = F, FE = F::Extension> + 'static,
         const D: usize,
-        const COLUMNS: usize,
     >(
-        stark: Starky<A, COLUMNS>,
+        stark: Starky<A>,
         config: StarkyConfig<F, C, D>,
         trace_generator: T,
         public_inputs: &[F],
@@ -304,7 +293,7 @@ pub(crate) mod tests {
 
         let num_rows = 1 << 5usize;
         let air = FibonacciAir::new();
-        let stark = Starky::<FibonacciAir, 2>::new(air);
+        let stark = Starky::<FibonacciAir>::new(air);
 
         let public_inputs = [
             F::ZERO,

--- a/curta/src/plonky2/stark/proof.rs
+++ b/curta/src/plonky2/stark/proof.rs
@@ -45,10 +45,10 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> S
         lde_bits - config.fri_config.rate_bits
     }
 
-    pub(crate) fn get_challenges<A: RAirData, const COLUMNS: usize>(
+    pub(crate) fn get_challenges<A: RAirData>(
         &self,
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         public_inputs: &[F],
         degree_bits: usize,
     ) -> StarkProofChallenges<F, D> {
@@ -131,13 +131,12 @@ impl<const D: usize> StarkProofTarget<D> {
         F: RichField + Extendable<D>,
         A: for<'a> RAir<RecursiveStarkParser<'a, F, D>>,
         C: GenericConfig<D, F = F>,
-        const COLUMNS: usize,
     >(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         config: &StarkyConfig<F, C, D>,
         public_inputs: &[Target],
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
     ) -> StarkProofChallengesTarget<D> {
         let StarkProofTarget {
             trace_caps,

--- a/curta/src/plonky2/stark/prover.rs
+++ b/curta/src/plonky2/stark/prover.rs
@@ -40,9 +40,9 @@ where
         Self(core::marker::PhantomData)
     }
 
-    pub fn prove<A, T, const COLUMNS: usize>(
+    pub fn prove<A, T>(
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         trace_generator: &T,
         public_inputs: &[F],
     ) -> Result<StarkProof<F, C, D>>
@@ -201,10 +201,10 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn quotient_polys<A, const COLUMNS: usize>(
+    fn quotient_polys<A>(
         degree_bits: usize,
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         trace_data: &[PolynomialBatch<F, C, D>],
         challenges_vars: &[P],
         global_vars: &[P],
@@ -237,15 +237,11 @@ where
         let z_h_on_coset = ZeroPolyOnCoset::<F>::new(degree_bits, quotient_degree_bits);
 
         // Retrieve the LDE values at index `i`.
-        let get_trace_values_packed = |i_start| -> [P; COLUMNS] {
-            let trace = trace_data
+        let get_trace_values_packed = |i_start| -> Vec<P> {
+            trace_data
                 .iter()
                 .flat_map(|commitment| commitment.get_lde_values_packed(i_start, step))
-                .collect::<Vec<_>>();
-            // .try_into()
-            // .expect("Invalid number of trace columns")
-            assert_eq!(trace.len(), COLUMNS);
-            trace.try_into().unwrap()
+                .collect()
         };
         // Last element of the subgroup.
         let last = F::primitive_root_of_unity(degree_bits).inverse();

--- a/curta/src/plonky2/stark/verifier.rs
+++ b/curta/src/plonky2/stark/verifier.rs
@@ -31,9 +31,9 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F, FE = F::Extension>,
 {
-    pub fn verify<A, const COLUMNS: usize>(
+    pub fn verify<A>(
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         proof: StarkProof<F, C, D>,
         public_inputs: &[F],
     ) -> Result<()>
@@ -140,9 +140,9 @@ where
         Ok(())
     }
 
-    pub fn validate_proof_shape<A: RAirData, const COLUMNS: usize>(
+    pub fn validate_proof_shape<A: RAirData>(
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         proof: &StarkProof<F, C, D>,
     ) -> Result<()> {
         let fri_params = config.fri_params();
@@ -169,8 +169,8 @@ where
         }
         ensure!(quotient_polys_cap.height() == cap_height);
         ensure!(global_values.len() == stark.air().num_global_values());
-        ensure!(local_values.len() == COLUMNS);
-        ensure!(next_values.len() == COLUMNS);
+        ensure!(local_values.len() == stark.air().num_columns());
+        ensure!(next_values.len() == stark.air().num_columns());
         ensure!(quotient_polys.len() == stark.num_quotient_polys(config));
 
         Ok(())
@@ -188,10 +188,10 @@ where
         (z_x * invs[0], z_x * invs[1])
     }
 
-    pub fn verify_circuit<A, const COLUMNS: usize>(
+    pub fn verify_circuit<A>(
         builder: &mut CircuitBuilder<F, D>,
         config: &StarkyConfig<F, C, D>,
-        stark: &Starky<A, COLUMNS>,
+        stark: &Starky<A>,
         proof: StarkProofTarget<D>,
         public_inputs: &[Target],
     ) where
@@ -325,10 +325,9 @@ pub fn add_virtual_stark_proof<
     A: for<'a> RAir<RecursiveStarkParser<'a, F, D>>,
     C: GenericConfig<D, F = F>,
     const D: usize,
-    const COLUMNS: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    stark: &Starky<A, COLUMNS>,
+    stark: &Starky<A>,
     config: &StarkyConfig<F, C, D>,
 ) -> StarkProofTarget<D>
 where
@@ -367,10 +366,9 @@ pub(crate) fn add_stark_opening_set_target<
     A: for<'a> RAir<RecursiveStarkParser<'a, F, D>>,
     C: GenericConfig<D, F = F>,
     const D: usize,
-    const COLUMNS: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    stark: &Starky<A, COLUMNS>,
+    stark: &Starky<A>,
     config: &StarkyConfig<F, C, D>,
 ) -> StarkOpeningSetTarget<D>
 where
@@ -378,8 +376,8 @@ where
 {
     let num_challenges = config.num_challenges;
     StarkOpeningSetTarget {
-        local_values: builder.add_virtual_extension_targets(COLUMNS),
-        next_values: builder.add_virtual_extension_targets(COLUMNS),
+        local_values: builder.add_virtual_extension_targets(stark.air().num_columns()),
+        next_values: builder.add_virtual_extension_targets(stark.air().num_columns()),
         quotient_polys: builder
             .add_virtual_extension_targets(stark.air().quotient_degree_factor() * num_challenges),
     }


### PR DESCRIPTION
Remove the use of all incomplete features.

The biggest change is forcing the starky prover to work with Vec instead of array when computing the vanishing polynomial, but it does not seem to affect performance (the reason might be that the array is obtained from a vector so the allocation cost is the same) 