### PR TITLE
fix: overflow bug

### DIFF
--- a/curta/src/chip/uint/bytes/operations/value.rs
+++ b/curta/src/chip/uint/bytes/operations/value.rs
@@ -41,7 +41,7 @@ impl ByteOperation<ByteRegister> {
                 opcode,
                 a.expr(),
                 ArithmeticExpression::from_constant(F::from_canonical_u8(*shift)),
-                result.expr() + (carry.expr() * F::from_canonical_u8(1 << (8 - shift))),
+                result.expr() + (carry.expr() * F::from_canonical_u16(1u16 << (8 - shift))),
             ],
             ByteOperation::Rot(a, b, result) => [opcode, a.expr(), b.expr(), result.expr()],
             ByteOperation::RotConst(a, b, c) => [

--- a/curta/src/chip/uint/operations/instruction.rs
+++ b/curta/src/chip/uint/operations/instruction.rs
@@ -289,8 +289,12 @@ mod tests {
 
         let num_ops = 20;
 
-        for _ in 0..num_ops {
-            let shift = rng.gen::<u64>() as usize;
+        for i in 0..num_ops {
+            let shift = if i == 0 {
+                32usize
+            } else {
+                rng.gen::<u64>() as usize
+            };
             shr_shift_vals.push(shift);
 
             let a_shr = builder.alloc::<ByteArrayRegister<N>>();


### PR DESCRIPTION
This PR fixes an overflow bug in the accumulation of `ShrCarry`. This operation would trigger a panic when the shift was a multiple of 8.

The source of the bug comes from `u8` which overflows on shift of 8. This was changed to a `u16` as originally intended.

 a test in u64_buye_operation was added for this edge case. 