### PR TITLE
chore: addressing comments in Weierstrass curve

### DIFF
--- a/curta/src/chip/ec/weierstrass/add.rs
+++ b/curta/src/chip/ec/weierstrass/add.rs
@@ -223,8 +223,8 @@ mod tests {
 
         let mut builder = AirBuilder::<L>::new();
 
-        let p = builder.alloc_swec_point();
-        let q = builder.alloc_swec_point();
+        let p = builder.alloc_sw_point();
+        let q = builder.alloc_sw_point();
 
         let _gadget = builder.sw_projective_add::<E>(&p, &q);
 
@@ -239,8 +239,8 @@ mod tests {
         let q_int = &base * &b;
         let writer = generator.new_writer();
         (0..L::num_rows()).into_par_iter().for_each(|i| {
-            writer.write_swec_point(&p, &p_int, i);
-            writer.write_swec_point(&q, &q_int, i);
+            writer.write_sw_point(&p, &p_int, i);
+            writer.write_sw_point(&q, &q_int, i);
             writer.write_row_instructions(&generator.air_data, i);
         });
 
@@ -279,7 +279,7 @@ mod tests {
 
         let mut builder = AirBuilder::<L>::new();
 
-        let p = builder.alloc_swec_point();
+        let p = builder.alloc_sw_point();
 
         let _gadget = builder.sw_projective_doubling::<E>(&p);
 
@@ -292,7 +292,7 @@ mod tests {
         let p_int = &base * &a;
         let writer = generator.new_writer();
         (0..L::num_rows()).into_par_iter().for_each(|i| {
-            writer.write_swec_point(&p, &p_int, i);
+            writer.write_sw_point(&p, &p_int, i);
             writer.write_row_instructions(&generator.air_data, i);
         });
 

--- a/curta/src/chip/ec/weierstrass/bn254.rs
+++ b/curta/src/chip/ec/weierstrass/bn254.rs
@@ -1,5 +1,5 @@
 //! Parameters for bn254 base field.
-use num::{BigUint, Zero};
+use num::{BigUint, Num, Zero};
 use serde::{Deserialize, Serialize};
 
 use super::projective::SWProjectivePoint;
@@ -36,9 +36,15 @@ impl EllipticCurveParameters for Bn254 {
     type BaseField = Bn254BaseField;
 }
 
+/// Bn254 Weierstrass curve: y^2 = x^3 + 3
 impl WeierstrassParameter for Bn254 {
     const A: [u16; crate::chip::field::parameters::MAX_NB_LIMBS] = [
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0,
+    ];
+
+    const B: [u16; crate::chip::field::parameters::MAX_NB_LIMBS] = [
+        3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ];
 
@@ -50,10 +56,18 @@ impl WeierstrassParameter for Bn254 {
     }
 
     fn prime_group_order() -> num::BigUint {
-        todo!()
+        BigUint::from_str_radix(
+            "21888242871839275222246405745257275088548364400416034343698204186575808495617",
+            10,
+        )
+        .unwrap()
     }
 
     fn a_biguint() -> BigUint {
         BigUint::zero()
+    }
+
+    fn b_biguint() -> BigUint {
+        BigUint::from(3u32)
     }
 }

--- a/curta/src/chip/ec/weierstrass/mod.rs
+++ b/curta/src/chip/ec/weierstrass/mod.rs
@@ -10,10 +10,14 @@ pub mod add;
 pub mod bn254;
 pub mod projective;
 
-/// Parameters for Weierstrass elliptic curve
+/// Parameters for Weierstrass elliptic curve of the form
+/// y^2 = x^3 + a * x + b
 pub trait WeierstrassParameter: EllipticCurveParameters {
     /// Constant `a` of the Weierstrass curve
     const A: [u16; MAX_NB_LIMBS];
+
+    /// Constant `b` of the Weierstrass curve
+    const B: [u16; MAX_NB_LIMBS];
 
     /// Returns a generator
     fn generator() -> SWProjectivePoint<Self>;
@@ -30,6 +34,15 @@ pub trait WeierstrassParameter: EllipticCurveParameters {
         modulus
     }
 
+    /// Returns the constant `b`
+    fn b_biguint() -> BigUint {
+        let mut modulus = BigUint::zero();
+        for (i, limb) in Self::B.iter().enumerate() {
+            modulus += BigUint::from(*limb) << (16 * i);
+        }
+        modulus
+    }
+
     /// Number of bits for scalar
     fn nb_scalar_bits() -> usize {
         Self::BaseField::NB_LIMBS * 16
@@ -38,8 +51,8 @@ pub trait WeierstrassParameter: EllipticCurveParameters {
     /// Returns a neutral point
     fn neutral() -> SWProjectivePoint<Self> {
         SWProjectivePoint::new(
-            BigUint::from(0u32),
-            BigUint::from(0u32),
+            BigUint::from(1u32),
+            BigUint::from(1u32),
             BigUint::from(0u32),
         )
     }

--- a/curta/src/chip/ec/weierstrass/projective.rs
+++ b/curta/src/chip/ec/weierstrass/projective.rs
@@ -16,7 +16,7 @@ use crate::chip::utils::{biguint_to_bits_le, field_limbs_to_biguint};
 use crate::chip::AirParameters;
 use crate::polynomial::to_u16_le_limbs_polynomial;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 /// short Weierstrass projective point
 pub struct SWProjectivePoint<E: EllipticCurveParameters> {
     /// x coordinate
@@ -40,7 +40,6 @@ impl<E: EllipticCurveParameters> SWProjectivePoint<E> {
     }
 }
 
-impl<E: EllipticCurveParameters> Eq for SWProjectivePoint<E> {}
 impl<E: EllipticCurveParameters> PartialEq for SWProjectivePoint<E> {
     fn eq(&self, other: &Self) -> bool {
         if self.z.is_zero() {
@@ -192,37 +191,37 @@ impl<E: EllipticCurveParameters> SWProjectivePointRegister<E> {
 pub trait SWProjectiveEllipticCurveGadget<E: EllipticCurveParameters> {
     /// Allocates registers for a SW Projective elliptic curve point without
     /// range-checking.
-    fn alloc_unchecked_swec_point(&mut self) -> SWProjectivePointRegister<E>;
+    fn alloc_unchecked_sw_point(&mut self) -> SWProjectivePointRegister<E>;
 
     /// Allocates local registers for a SW Projective point
-    fn alloc_local_swec_point(&mut self) -> SWProjectivePointRegister<E>;
+    fn alloc_local_sw_point(&mut self) -> SWProjectivePointRegister<E>;
 
     /// Allocates next registers for a SW Projective point
-    fn alloc_next_swec_point(&mut self) -> SWProjectivePointRegister<E>;
+    fn alloc_next_sw_point(&mut self) -> SWProjectivePointRegister<E>;
 
     /// Allocates registers for a SW Projective point
-    fn alloc_swec_point(&mut self) -> SWProjectivePointRegister<E> {
-        self.alloc_local_swec_point()
+    fn alloc_sw_point(&mut self) -> SWProjectivePointRegister<E> {
+        self.alloc_local_sw_point()
     }
 
     /// Allocates global registers for a SW Projective point
-    fn alloc_global_swec_point(&mut self) -> SWProjectivePointRegister<E>;
+    fn alloc_global_sw_point(&mut self) -> SWProjectivePointRegister<E>;
 
     /// Allocates public registers for a SW Projective point
-    fn alloc_public_swec_point(&mut self) -> SWProjectivePointRegister<E>;
+    fn alloc_public_sw_point(&mut self) -> SWProjectivePointRegister<E>;
 }
 
 /// I/O for SW elliptic curve registers
 pub trait SWEllipticCurveWriter<E: EllipticCurveParameters> {
     /// Read SW elliptic curve point from registers
-    fn read_swec_point(
+    fn read_sw_point(
         &self,
         data: &SWProjectivePointRegister<E>,
         row_index: usize,
     ) -> SWProjectivePoint<E>;
 
     /// Write SW elliptic curve point into registers
-    fn write_swec_point(
+    fn write_sw_point(
         &self,
         data: &SWProjectivePointRegister<E>,
         value: &SWProjectivePoint<E>,
@@ -235,7 +234,7 @@ impl<L: AirParameters, E: EllipticCurveParameters> SWProjectiveEllipticCurveGadg
 {
     /// Allocates registers for a SW Projective elliptic curve point without
     /// range-checking.
-    fn alloc_unchecked_swec_point(&mut self) -> SWProjectivePointRegister<E> {
+    fn alloc_unchecked_sw_point(&mut self) -> SWProjectivePointRegister<E> {
         let x = FieldRegister::<E::BaseField>::from_register(
             self.get_local_memory(E::BaseField::NB_LIMBS),
         );
@@ -248,28 +247,28 @@ impl<L: AirParameters, E: EllipticCurveParameters> SWProjectiveEllipticCurveGadg
         SWProjectivePointRegister::new(x, y, z)
     }
 
-    fn alloc_local_swec_point(&mut self) -> SWProjectivePointRegister<E> {
+    fn alloc_local_sw_point(&mut self) -> SWProjectivePointRegister<E> {
         let x = self.alloc::<FieldRegister<E::BaseField>>();
         let y = self.alloc::<FieldRegister<E::BaseField>>();
         let z = self.alloc::<FieldRegister<E::BaseField>>();
         SWProjectivePointRegister::new(x, y, z)
     }
 
-    fn alloc_next_swec_point(&mut self) -> SWProjectivePointRegister<E> {
+    fn alloc_next_sw_point(&mut self) -> SWProjectivePointRegister<E> {
         let x = self.alloc::<FieldRegister<E::BaseField>>();
         let y = self.alloc::<FieldRegister<E::BaseField>>();
         let z = self.alloc::<FieldRegister<E::BaseField>>();
         SWProjectivePointRegister::new(x, y, z)
     }
 
-    fn alloc_global_swec_point(&mut self) -> SWProjectivePointRegister<E> {
+    fn alloc_global_sw_point(&mut self) -> SWProjectivePointRegister<E> {
         let x = self.alloc::<FieldRegister<E::BaseField>>();
         let y = self.alloc::<FieldRegister<E::BaseField>>();
         let z = self.alloc::<FieldRegister<E::BaseField>>();
         SWProjectivePointRegister::new(x, y, z)
     }
 
-    fn alloc_public_swec_point(&mut self) -> SWProjectivePointRegister<E> {
+    fn alloc_public_sw_point(&mut self) -> SWProjectivePointRegister<E> {
         let x = self.alloc::<FieldRegister<E::BaseField>>();
         let y = self.alloc::<FieldRegister<E::BaseField>>();
         let z = self.alloc::<FieldRegister<E::BaseField>>();
@@ -278,7 +277,7 @@ impl<L: AirParameters, E: EllipticCurveParameters> SWProjectiveEllipticCurveGadg
 }
 
 impl<F: PrimeField64, E: EllipticCurveParameters> SWEllipticCurveWriter<E> for TraceWriter<F> {
-    fn read_swec_point(
+    fn read_sw_point(
         &self,
         data: &SWProjectivePointRegister<E>,
         row_index: usize,
@@ -294,7 +293,7 @@ impl<F: PrimeField64, E: EllipticCurveParameters> SWEllipticCurveWriter<E> for T
         SWProjectivePoint::<E>::new(x, y, z)
     }
 
-    fn write_swec_point(
+    fn write_sw_point(
         &self,
         data: &SWProjectivePointRegister<E>,
         value: &SWProjectivePoint<E>,


### PR DESCRIPTION
This PR addresses leftover comments by @alxiong in https://github.com/succinctlabs/curta/pull/75

2 unaddressed issues:

> instead of defining a new trait. we should generalize the original `ec/gadget.rs::trait EllipticCurveGadget` instead by introducing an associated type called `type PointRegister`.

This could be a future refactor work, as it touches other interfaces design.

> great reference algorithm! but should add unit tests. (maybe cross-check with arkwork's implementation?)
> 
> I don't see any tests checking its correctness.

Will do it in the future.