### PR TITLE
fix: multiplication by zero for edwards curves

### DIFF
--- a/curta/src/chip/ec/edwards/mod.rs
+++ b/curta/src/chip/ec/edwards/mod.rs
@@ -63,6 +63,10 @@ impl<E: EdwardsParameters> EllipticCurve for EdwardsCurve<E> {
         AffinePoint::new(x, y)
     }
 
+    fn ec_neutral() -> Option<AffinePoint<Self>> {
+        Some(Self::neutral())
+    }
+
     fn ec_neg(p: &AffinePoint<Self>) -> AffinePoint<Self> {
         let modulus = E::BaseField::modulus();
         AffinePoint::new(&modulus - &p.x, p.y.clone())

--- a/curta/src/chip/ec/mod.rs
+++ b/curta/src/chip/ec/mod.rs
@@ -15,15 +15,27 @@ pub trait EllipticCurveParameters: Debug + Send + Sync + Copy + 'static {
     type BaseField: FieldParameters;
 }
 
+/// An interface for elliptic curve groups.
 pub trait EllipticCurve: EllipticCurveParameters {
+    /// Adds two different points on the curve.
+    ///
+    /// Warning: This method assumes that the two points are different.
     fn ec_add(p: &AffinePoint<Self>, q: &AffinePoint<Self>) -> AffinePoint<Self>;
 
+    /// Doubles a point on the curve.
     fn ec_double(p: &AffinePoint<Self>) -> AffinePoint<Self>;
 
+    /// Returns the generator of the curve group for a curve/subgroup of prime order.
     fn ec_generator() -> AffinePoint<Self>;
 
+    /// Returns the neutral element of the curve group, if this element is affine (such as in the
+    /// case of the Edwards curve group). Otherwise, returns `None`.
+    fn ec_neutral() -> Option<AffinePoint<Self>>;
+
+    /// Returns the negative of a point on the curve.
     fn ec_neg(p: &AffinePoint<Self>) -> AffinePoint<Self>;
 
+    /// Returns the number of bits needed to represent a scalar in the group.
     fn nb_scalar_bits() -> usize {
         Self::BaseField::NB_LIMBS * Self::BaseField::NB_BITS_PER_LIMB
     }

--- a/curta/src/chip/ec/scalar_mul/mod.rs
+++ b/curta/src/chip/ec/scalar_mul/mod.rs
@@ -10,7 +10,7 @@ impl<E: EllipticCurve> AffinePoint<E> {
     fn scalar_mul(&self, scalar: &BigUint) -> Self {
         let power_two_modulus = BigUint::one() << E::nb_scalar_bits();
         let scalar = scalar % &power_two_modulus;
-        let mut result = None;
+        let mut result = E::ec_neutral();
         let mut temp = self.clone();
         let bits = biguint_to_bits_le(&scalar, E::nb_scalar_bits());
         for bit in bits {
@@ -19,7 +19,7 @@ impl<E: EllipticCurve> AffinePoint<E> {
             }
             temp = &temp + &temp;
         }
-        result.expect("Scalar cannot be zero")
+        result.expect("Scalar multiplication failed")
     }
 }
 

--- a/curta/src/chip/ec/weierstrass/mod.rs
+++ b/curta/src/chip/ec/weierstrass/mod.rs
@@ -64,6 +64,10 @@ impl<E: WeierstrassParameters> EllipticCurve for SWCurve<E> {
         AffinePoint::new(x, y)
     }
 
+    fn ec_neutral() -> Option<AffinePoint<Self>> {
+        None
+    }
+
     fn ec_neg(p: &AffinePoint<Self>) -> AffinePoint<Self> {
         let modulus = E::BaseField::modulus();
         AffinePoint::new(p.x.clone(), modulus - &p.y)


### PR DESCRIPTION
Restore the ability to multiply by zero when doing scalar multiplication on Edwards curves.