### PR TITLE
chore: fix typos in comments

### DIFF
--- a/curta/examples/ed_scalar_mul.rs
+++ b/curta/examples/ed_scalar_mul.rs
@@ -12,7 +12,7 @@
 //! RUST_LOG="debug" cargo run --release --example ed_scalar_mul
 //! ```
 //!
-//! For maximum performence, set the compiler flag to optimize for your CPU architecture:
+//! For maximum performance, set the compiler flag to optimize for your CPU architecture:
 //! ```
 //! RUST_LOG="debug" RUSTFLAGS=-Ctarget-cpu=native cargo run --release --example ed_scalar_mul
 //! ```
@@ -88,7 +88,7 @@ fn main() {
 
     // These results will be allocated automatically into the trace once `points` and
     // `scalars` are written into the trace.
-    // We can compare these results with the expected results by writing these explicitely
+    // We can compare these results with the expected results by writing these explicitly
     // into the trace.
     let expected_results = (0..256)
         .map(|_| {
@@ -103,7 +103,7 @@ fn main() {
         builder.register_public_inputs(&point.y);
     }
 
-    // Compare the results to the expeced results
+    // Compare the results to the expected results
     for (res, expected) in results.iter().zip(expected_results.iter()) {
         builder.connect_affine_point(res, expected);
     }

--- a/curta/examples/sha256.rs
+++ b/curta/examples/sha256.rs
@@ -13,7 +13,7 @@
 //! RUST_LOG="debug" cargo run --release --example sha256
 //! ```
 //!
-//! For maximum performence, set the compiler flag to optimize for your CPU architecture:
+//! For maximum performance, set the compiler flag to optimize for your CPU architecture:
 //! ```
 //! RUST_LOG="debug" RUSTFLAGS=-Ctarget-cpu=native cargo run --release --example sha256
 //! ```

--- a/curta/src/chip/hash/blake/blake2b/mod.rs
+++ b/curta/src/chip/hash/blake/blake2b/mod.rs
@@ -231,7 +231,7 @@ impl<L: AirParameters> AirBuilder<L> {
     // The blake2b specification actually does allow t to be up to 2**128-1
     // (see https://en.wikipedia.org/wiki/BLAKE_(hash_function)).
     // Also, we currently only support digest size of 32 bytes and no usage of a key.
-    // This restricted support means that we can have a seperate constant for h0 in compress
+    // This restricted support means that we can have a separate constant for h0 in compress
     // instead of having to mutate it.
     #[allow(clippy::too_many_arguments)]
     fn blake2b_compress(

--- a/curta/src/chip/register/mod.rs
+++ b/curta/src/chip/register/mod.rs
@@ -59,7 +59,7 @@ pub trait Register:
 {
     type Value<T>;
 
-    // Determins the layout of Value<T> as a slice that can be assigned to the trace.
+    // Determines the layout of Value<T> as a slice that can be assigned to the trace.
     fn align<T>(value: &Self::Value<T>) -> &[T];
 
     // Gets a new value from a slice.


### PR DESCRIPTION
fix minor typos in comments