### PR TITLE
fix: sha bug for large tables

### DIFF
--- a/curta/src/chip/memory/pointer/slice.rs
+++ b/curta/src/chip/memory/pointer/slice.rs
@@ -45,6 +45,7 @@ impl<V: MemoryValue> Slice<V> {
 
 impl RawSlice {
     pub(crate) fn get(&self, idx: usize) -> RawPointer {
+        assert!(idx <= i32::MAX as usize);
         RawPointer::new(self.challenge, None, Some(idx as i32))
     }
 

--- a/curta/src/chip/uint/register.rs
+++ b/curta/src/chip/uint/register.rs
@@ -77,17 +77,17 @@ impl MemoryValue for U32Register {
         time: &Time<L::Field>,
     ) -> CubicRegister {
         let bytes = self.to_le_bytes();
-        let mut acc_expression = ArithmeticExpression::zero();
+        let mut acc = ArithmeticExpression::zero();
 
         for (i, byte) in bytes.iter().enumerate() {
             let two_i = ArithmeticExpression::from(L::Field::from_canonical_u32(1 << (8 * i)));
-            acc_expression = acc_expression + two_i * byte.expr();
+            acc = acc + two_i * byte.expr();
         }
 
-        let two_32 = ArithmeticExpression::from(L::Field::from_canonical_u64(1 << 32));
-        acc_expression = acc_expression + two_32 * time.expr();
+        let zero = ArithmeticExpression::zero();
+        let acc_expression = CubicElement([acc, time.expr(), zero]);
 
-        ptr.accumulate(builder, acc_expression)
+        ptr.accumulate_cubic(builder, acc_expression)
     }
 }
 

--- a/curta/src/machine/bytes/stark.rs
+++ b/curta/src/machine/bytes/stark.rs
@@ -725,7 +725,7 @@ mod tests {
 
         let a_init = builder.alloc_array_public::<U32Register>(4);
 
-        let num_rows = 1 << 5;
+        let num_rows = 1 << 20;
 
         let a_ptr = builder.initialize_slice::<U32Register>(&a_init, &Time::zero(), None);
 

--- a/curta/src/machine/hash/sha/sha256/air.rs
+++ b/curta/src/machine/hash/sha/sha256/air.rs
@@ -222,7 +222,7 @@ mod tests {
     fn test_sha256_short_message() {
         let msg = b"abc";
         let expected_digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
-        let num_messages = 1;
+        let num_messages = 2048;
         test_sha256(
             iter::repeat(msg).take(num_messages).map(|x| x.as_slice()),
             iter::repeat(expected_digest).take(num_messages),
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_sha256_long_message() {
-        let num_messages = 2000;
+        let num_messages = 1023;
         let msg = hex::decode("243f6a8885a308d313198a2e03707344a4093822299f31d0082efa98ec4e6c89452821e638d01377be5466cf34e90c6cc0ac29b7c97c50dd3f84d5b5b5470917").unwrap();
         let expected_digest = "aca16131a2e4c4c49e656d35aac1f0e689b3151bb108fa6cf5bcc3ac08a09bf9";
         test_sha256(

--- a/curta/src/machine/hash/sha/sha256/air.rs
+++ b/curta/src/machine/hash/sha/sha256/air.rs
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_sha256_long_message() {
-        let num_messages = 2;
+        let num_messages = 2000;
         let msg = hex::decode("243f6a8885a308d313198a2e03707344a4093822299f31d0082efa98ec4e6c89452821e638d01377be5466cf34e90c6cc0ac29b7c97c50dd3f84d5b5b5470917").unwrap();
         let expected_digest = "aca16131a2e4c4c49e656d35aac1f0e689b3151bb108fa6cf5bcc3ac08a09bf9";
         test_sha256(


### PR DESCRIPTION
A dummy index in the SHA air was too small causing collisions in the memory reading for tables larger than 2^17. The dummy index was changes to `i32::MAX` and assert statements were added.