### PR TITLE
feat: add a watcher 

### DIFF
--- a/curta/src/machine/builder/mod.rs
+++ b/curta/src/machine/builder/mod.rs
@@ -264,6 +264,13 @@ pub trait Builder: Sized {
         register
     }
 
+    /// Prints out a log message (using the log::debug! macro) with the value of the register.
+    ///
+    /// The message will be presented with `RUST_LOG=debug` or `RUST_LOG=trace`.
+    fn watch(&mut self, data: &impl Register, name: &str) {
+        self.api().watch(data, name);
+    }
+
     /// Computes the expression `expression` and returns the result as a public register of type `T`.
     fn public_expression<T: Register>(
         &mut self,

--- a/curta/src/machine/stark/mod.rs
+++ b/curta/src/machine/stark/mod.rs
@@ -424,7 +424,8 @@ mod tests {
 
         let a = builder.alloc::<FieldRegister<Fp25519>>();
         let b = builder.alloc::<FieldRegister<Fp25519>>();
-        let _ = builder.add(a, b);
+        let c = builder.add(a, b);
+        builder.watch(&c, "c");
 
         let num_rows = 1 << 16;
         let stark = builder.build::<C, 2>(num_rows);


### PR DESCRIPTION
We can now watch values that are being written using the function
```rust
builder.watch(&data, name);
```
during trace writing, the value will be printed to the logger on the debug level. 

**Note**: since instructions are registered to the builder in the order they are written, you must add the "watch" **after**  any instruction that might change the value of that data type. 